### PR TITLE
Search for merged PRs by commits, instead of error-prone commit message

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ async function main({ ctx }) {
 
       page = 1;
       while (true) {
+        core.debug(`Fetching page ${page} of PRs matching q: ${q}`);
         const {
           data: { incomplete_results, items: prs },
         } = await githubRest.search.issuesAndPullRequests({ q, per_page, page });


### PR DESCRIPTION
This used to pull the PR #s out of commit messages, and then fetch those PRs one by one to get the title for the summary. Now it directly searches for merged PRs into the destination branch that contain one of the commits in the diff. This should be less error-prone and faster, on average.