### PR TITLE
Feature: Tag PR author of each line in the merge_commits_summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Focus the summary on merges into this branch. Default: 'master'
 
 The summary of merge commits into {describe_merges_into_branch}. Example:
 
- - [#1](https://github.com/knockaway/gh-action-promotion-pr-params/pull/1): Add example section to merge_commits_summary
- - [#2](https://github.com/knockaway/gh-action-promotion-pr-params/pull/2): Update example section in merge_commits_summary
+ - [#1](https://github.com/knockaway/gh-action-promotion-pr-params/pull/1) by @user1: Add example section to merge_commits_summary
+ - [#2](https://github.com/knockaway/gh-action-promotion-pr-params/pull/2) by @user2: Update example section in merge_commits_summary
 
 ### `merge_commits_summary_json`
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build Promotion PR Params
         id: promotion_pr_params
-        uses: knockaway/gh-action-promotion-pr-params@v1.1.0
+        uses: knockaway/gh-action-promotion-pr-params@v1.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_source_branch: ${{ env.HEAD_BRANCH }}

--- a/index.js
+++ b/index.js
@@ -103,7 +103,11 @@ async function main({ ctx }) {
 
     const prLines = [];
     for (const pr of [...prNumberToPr.values()].sort(byClosedAtDesc)) {
-      prLines.push(`[#${pr.number}](${pr.html_url}): ${pr.title}`);
+      if (pr.user?.login && isLoginPermissible(pr.user.login)) {
+        prLines.push(`[#${pr.number}](${pr.html_url}) by @${pr.user.login}: ${pr.title}`);
+      } else {
+        prLines.push(`[#${pr.number}](${pr.html_url}): ${pr.title}`);
+      }
     }
 
     const commitSummary = prLines.map(line => ` - ${line}`).join('\n');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knockaway/gh-action-promotion-pr-params",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This can help to show which PRs a reviewer is responsible for approving for promotion, rather than opening each PR individually to see the author.